### PR TITLE
Add nudge and auto reschedule capabilities

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Googleカレンダー連携 API",
-    "version": "1.2.3",
-    "description": "GAS 経由で Google カレンダーに予定を作成・照会（list/freebusy）。時間指定/終日/別カレンダー/自動衝突回避/翌営業日ロール対応。JST想定。"
+    "version": "1.3.0",
+    "description": "GAS 経由で Google カレンダーに予定を作成・照会（list/freebusy/nudge/reschedulePending）。時間指定/終日/別カレンダー/自動衝突回避/翌営業日ロール対応。JST想定。"
   },
   "servers": [
     { "url": "https://script.google.com" }
@@ -22,7 +22,7 @@
                 "properties": {
                   "action": {
                     "type": "string",
-                    "description": "list/freebusy 指定時は照会モード。未指定は予定作成。"
+                    "description": "list/freebusy/nudge/reschedulePending を指定すると照会・補助モード。未指定時は予定作成。"
                   },
                   "calendarId": { "type": "string" },
                   "timeMin": {
@@ -36,6 +36,10 @@
                   "pageToken": { "type": "string" },
                   "title": { "type": "string" },
                   "description": { "type": "string" },
+                  "eventId": {
+                    "type": "string",
+                    "description": "nudge/reschedule 対象のイベントID（Calendar API の eventId または iCalUID）"
+                  },
                   "date": {
                     "type": "string",
                     "description": "予定日 (YYYY-MM-DD)",
@@ -62,6 +66,10 @@
                   },
                   "minGapMinutes": { "type": "number" },
                   "autoAvoidConflict": { "type": "boolean" },
+                  "time": {
+                    "type": "string",
+                    "description": "reschedulePending 実行基準時刻 (RFC3339)"
+                  },
                   "meta": {
                     "type": "object",
                     "description": "タスクメタ情報（プロジェクト/締切/難易度など）",
@@ -117,6 +125,12 @@
                 },
                 "FreeBusy": {
                   "value": { "action": "freebusy", "timeMin": "2025-09-22T00:00:00+09:00", "timeMax": "2025-09-23T00:00:00+09:00" }
+                },
+                "Nudge": {
+                  "value": { "action": "nudge", "eventId": "abc123@google.com" }
+                },
+                "Reschedule": {
+                  "value": { "action": "reschedulePending", "time": "2025-09-22T20:00:00+09:00" }
                 }
               }
             }
@@ -135,16 +149,51 @@
                     "summary": { "type": "string" },
                     "description": { "type": "string" },
                     "descriptionPlain": { "type": "string" },
-                    "meta": {
-                      "type": "object",
-                      "description": "---META--- ブロックから抽出された情報",
-                      "additionalProperties": true
-                    },
-                    "priorityScore": { "type": "number" },
-                    "start": { "type": "object" },
-                    "end": { "type": "object" }
+                  "meta": {
+                    "type": "object",
+                    "description": "---META--- ブロックから抽出された情報",
+                    "additionalProperties": true
                   },
-                  "additionalProperties": true
+                  "priorityScore": { "type": "number" },
+                  "firstStep": { "type": "string" },
+                  "checklist": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "nudge アクションで返却される補助チェックリスト"
+                  },
+                  "ifThen": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "nudge アクションで返却される if-then 提案"
+                  },
+                  "event": {
+                    "type": "object",
+                    "description": "nudge 用に返却される元イベントの概要",
+                    "additionalProperties": true
+                  },
+                  "checkedAt": {
+                    "type": "string",
+                    "description": "reschedulePending の実行時刻 (RFC3339)"
+                  },
+                  "rescheduled": {
+                    "type": "array",
+                    "description": "reschedulePending で移動したイベント情報",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "eventId": { "type": "string" },
+                        "newDate": { "type": "string" },
+                        "newStart": { "type": "object" },
+                        "priorityScore": { "type": "number" }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "start": { "type": "object" },
+                  "end": { "type": "object" }
+                },
+                "additionalProperties": true
                 }
               }
             }


### PR DESCRIPTION
## Summary
- add helper utilities and entry points for `nudge` suggestions plus automatic rescheduling of overdue tasks in the Apps Script backend
- update the OpenAPI document to expose the new `nudge` and `reschedulePending` actions and their response payloads

## Testing
- `python -m json.tool openapi.json`


------
https://chatgpt.com/codex/tasks/task_e_68d0fe4385808321b6617c62719eabc2